### PR TITLE
Adjust versioning

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,23 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v0.9.2
 
+    - name: Version variables for unstable builds
+      id: unstable
+      if: startsWith(github.ref, 'refs/tags/') != true
+      env:
+        LABEL: ${{ steps.gitversion.outputs.preReleaseTagWithDash }}.${{ steps.gitversion.outputs.commitsSinceVersionSourcePadded }}
+      run: |
+        echo "Pre-release: ${LABEL}"
+        echo "::set-output name=label::${LABEL}"
+
+    - name: Create gem version number
+      id: gemversion
+      env:
+        GEM_VERSION: "${{ steps.gitversion.outputs.majorMinorPatch }}${{ steps.unstable.outputs.label }}"
+      run: |
+        echo "Gem version: ${GEM_VERSION}"
+        echo "::set-output name=version::${GEM_VERSION}"
+
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
@@ -49,13 +66,13 @@ jobs:
 
     - name: Test with Rake
       env:
-        VERSION: ${{ steps.gitversion.outputs.fullSemVer }}
+        GEM_VERSION: ${{ steps.gemversion.outputs.version }}
       run: bundle exec rake
 
     - name: Build gem
       id: gem
       env:
-        VERSION: ${{ steps.gitversion.outputs.fullSemVer }}
+        GEM_VERSION: ${{ steps.gemversion.outputs.version }}
       run: |
         GEM_BUILD_NAME=$(gem build kramdown-plantuml.gemspec | awk '/File/ {print $2}')
         echo "Gem filename: '${GEM_BUILD_NAME}'"

--- a/lib/kramdown-plantuml/version.rb
+++ b/lib/kramdown-plantuml/version.rb
@@ -1,6 +1,6 @@
 module Kramdown
   module PlantUml
-    @version = ENV['VERSION'] || '0.0.1-INVALID'
+    @version = ENV['GEM_VERSION'] || '0.0.1-INVALID'
     VERSION = @version
   end
 end


### PR DESCRIPTION
- Rename the environment variable from `VERSION` to `GEM_VERSION`
- Mint custom gem version number so unstable builds generate version numbers compatible with RubyGems.