### PR TITLE
Execute GitVersion for tagged builds

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,13 +20,11 @@ jobs:
 
     - name: Setup GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.4
-      if: startsWith(github.ref, 'refs/tags/') != true # Only use GitVersion for unstable builds
       with:
         versionSpec: '5.3.x'
 
     - name: Execute GitVersion
       id: gitversion
-      if: startsWith(github.ref, 'refs/tags/') != true
       uses: gittools/actions/gitversion/execute@v0.9.4
 
     - name: Create variables


### PR DESCRIPTION
Always execute GitVersion, even for tagged builds.