### PR TITLE
Add missing SimpleCov.start statement

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,3 +100,8 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+if ENV.fetch('GITHUB_ACTIONS', false) || ENV.fetch('COVER', false)
+  require 'simplecov'
+  SimpleCov.start
+end


### PR DESCRIPTION
Add missing `SimpleCov.start` statement so code coverage is actually gathered when executing specs.