### PR TITLE
Change GITHUB_TOKEN to GPR_TOKEN

### DIFF
--- a/.github/scripts/bundle-install.sh
+++ b/.github/scripts/bundle-install.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -o errexit # Abort if any command fails
-
-gem install bundler
-bundle config path vendor/bundle
-bundle install --jobs 4 --retry 3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -82,23 +82,14 @@ jobs:
     - name: Version stamp
       run: sed -i -e 's/0.0.1.dev/${{ needs.version.outputs.version }}/g' ${{ github.workspace }}/lib/kramdown-plantuml/version.rb
 
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+    - name: Setup Ruby 2.7
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
+        ruby-version: 2.7
+        bundler-cache: true
 
     - name: Setup Graphviz
       uses: kamiazya/setup-graphviz@v1
-
-    - name: Cache Ruby gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gems-
-
-    - name: Bundle install
-      run: .github/scripts/bundle-install.sh
 
     - name: rubocop
       run: bundle exec rubocop --fail-level warning --display-only-fail-level-offenses

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -145,10 +145,10 @@ jobs:
       uses: kamiazya/setup-graphviz@v1
 
     - name: Publish to GPR
-      run: .github/scripts/publish-gem.sh --gem ${{ needs.gem.outputs.name }} --token ${{ secrets.GITHUB_TOKEN }} --owner SwedbankPay --verbose
+      run: .github/scripts/publish-gem.sh --gem ${{ needs.gem.outputs.name }} --token ${{ secrets.GPR_TOKEN }} --owner SwedbankPay --verbose
 
     - name: Test gem
-      run: .github/scripts/test-gem.sh --workdir "${{ github.workspace }}/spec/fixture" --version ${{ needs.version.outputs.version }} --token "${{ secrets.GITHUB_TOKEN }}" --verbose
+      run: .github/scripts/test-gem.sh --workdir "${{ github.workspace }}/spec/fixture" --version ${{ needs.version.outputs.version }} --token "${{ secrets.GPR_TOKEN }}" --verbose
 
   publish-prod:
     needs: [version, gem]

--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ The code within this repository is available as open source under the terms of
 the [Apache 2.0 License][license] and the [contributor's license
 agreement][cla].
 
-[build-badge]:          https://github.com/SwedbankPay/kramdown-plantuml/workflows/Ruby%20Gem/badge.svg?branch=master
+[build-badge]:          https://github.com/SwedbankPay/kramdown-plantuml/workflows/Ruby%20Gem/badge.svg?branch=main
 [cla-badge]:            https://cla-assistant.io/readme/badge/SwedbankPay/kramdown-plantuml
 [cla]:                  https://cla-assistant.io/SwedbankPay/kramdown-plantuml
 [clone]:                https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/cloning-a-repository
 [coc-badge]:            https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg
 [coc]:                  ./CODE_OF_CONDUCT.md
 [codecov]:              https://codecov.io/gh/SwedbankPay/kramdown-plantuml/
-[codecov-badge]:        https://codecov.io/gh/SwedbankPay/kramdown-plantuml/branch/master/graph/badge.svg?token=U3QJLVG3HY
+[codecov-badge]:        https://codecov.io/gh/SwedbankPay/kramdown-plantuml/branch/main/graph/badge.svg?token=U3QJLVG3HY
 [dependabot-badge]:     https://api.dependabot.com/badges/status?host=github&repo=SwedbankPay/kramdown-plantuml
 [dependabot]:           https://dependabot.com
 [diagram-svg]:          ./spec/diagram.svg
@@ -131,8 +131,8 @@ agreement][cla].
 [kramdown]:             https://kramdown.gettalong.org/
 [license-badge]:        https://img.shields.io/github/license/SwedbankPay/kramdown-plantuml
 [license]:              https://opensource.org/licenses/Apache-2.0
-[no-java-build-badge]:  https://github.com/SwedbankPay/kramdown-plantuml/workflows/No%20Java/badge.svg?branch=master
-[no-plantuml-badge]:    https://github.com/SwedbankPay/kramdown-plantuml/workflows/No%20PlantUML/badge.svg?branch=master
+[no-java-build-badge]:  https://github.com/SwedbankPay/kramdown-plantuml/workflows/No%20Java/badge.svg?branch=main
+[no-plantuml-badge]:    https://github.com/SwedbankPay/kramdown-plantuml/workflows/No%20PlantUML/badge.svg?branch=main
 [plantuml]:             https://plantuml.com/
 [pr]:                   https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 [svg]:                  https://developer.mozilla.org/en-US/docs/Web/SVG


### PR DESCRIPTION
Change `GITHUB_TOKEN` to `GPR_TOKEN` so pull requests from Dependabot can be published successfully to GPR.