### PR TITLE
DX-914: More fixes

### DIFF
--- a/kramdown-plantuml.gemspec
+++ b/kramdown-plantuml.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'htmlentities', '~> 4'
   spec.add_dependency 'kramdown', '~> 2.3'
   spec.add_dependency 'kramdown-parser-gfm', '~> 1.1'
   spec.add_dependency 'open3', '~> 0.1'

--- a/lib/kramdown-plantuml/jekyll_provider.rb
+++ b/lib/kramdown-plantuml/jekyll_provider.rb
@@ -62,10 +62,6 @@ module Kramdown
           html.gsub(/<!--#kramdown-plantuml\.start#-->(?<json>.*?)<!--#kramdown-plantuml\.end#-->/m) do
             json = $LAST_MATCH_INFO[:json]
             return replace_needle(json)
-          rescue StandardError => e
-            raise e if options.raise_errors?
-
-            logger.error "Error while replacing needle: #{e.inspect}"
           end
         end
 

--- a/lib/kramdown_html.rb
+++ b/lib/kramdown_html.rb
@@ -28,7 +28,7 @@ module Kramdown
         options = ::Kramdown::PlantUml::Options.new(@options)
         return jekyll.needle(element.value, options) if jekyll.installed?
 
-        convert_plantuml(element.value)
+        convert_plantuml(element.value, options)
       end
 
       private
@@ -37,10 +37,13 @@ module Kramdown
         element.attr['class'] == 'language-plantuml'
       end
 
-      def convert_plantuml(plantuml)
-        options = ::Kramdown::PlantUml::Options.new(@options)
+      def convert_plantuml(plantuml, options)
         diagram = ::Kramdown::PlantUml::Diagram.new(plantuml, options)
         diagram.convert_to_svg
+      rescue StandardError => e
+        raise e if options.raise_errors?
+
+        logger.error "Error while replacing needle: #{e.inspect}"
       end
     end
   end


### PR DESCRIPTION
Even more fixes for [this](https://github.com/SwedbankPay/swedbank-pay-design-guide-jekyll-theme/runs/4068912886?check_suite_focus=true#step:3:549):

```ruby
/usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:66:in `rescue in block in replace_needles': undefined local variable or method `options' for Kramdown::PlantUml::JekyllProvider:Module (NameError)
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:63:in `block in replace_needles'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:62:in `gsub'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:62:in `replace_needles'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:29:in `block (2 levels) in install'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:28:in `each'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:28:in `block in install'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/hooks.rb:103:in `block in trigger'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/hooks.rb:102:in `each'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/hooks.rb:102:in `trigger'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/site.rb:213:in `render'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/site.rb:80:in `process'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/command.rb:28:in `process_site'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/commands/build.rb:65:in `build'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/commands/build.rb:36:in `process'
	from /var/jekyll/entrypoint/lib/commands/jekyll_builder.rb:18:in `execute'
	from /var/jekyll/entrypoint/lib/commander.rb:88:in `build'
	from /var/jekyll/entrypoint/lib/commander.rb:65:in `execute_command'
	from /var/jekyll/entrypoint/lib/commander.rb:55:in `execute_args'
	from /var/jekyll/entrypoint/lib/commander.rb:36:in `execute'
	from /var/jekyll/entrypoint/lib/entrypoint.rb:21:in `execute'
	from /var/jekyll/entrypoint/lib/entrypoint.rb:45:in `<main>'
```

And [this](https://github.com/SwedbankPay/swedbank-pay-design-guide-jekyll-theme/runs/4068912886?check_suite_focus=true#step:3:571):

```ruby
Line: 20
Position: 324
Last 80 unconsumed characters:
<- client @enduml </plantuml>
	from /usr/gem/ruby/2.7.0/gems/rexml-3.2.5/lib/rexml/parsers/baseparser.rb:183:in `pull'
	from /usr/gem/ruby/2.7.0/gems/rexml-3.2.5/lib/rexml/parsers/treeparser.rb:23:in `parse'
	from /usr/gem/ruby/2.7.0/gems/rexml-3.2.5/lib/rexml/document.rb:448:in `build'
	from /usr/gem/ruby/2.7.0/gems/rexml-3.2.5/lib/rexml/document.rb:101:in `initialize'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:82:in `new'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:82:in `decode_html_entities'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:75:in `replace_needle'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:64:in `block in replace_needles'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:62:in `gsub'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:62:in `replace_needles'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:29:in `block (2 levels) in install'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:28:in `each'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.7/lib/kramdown-plantuml/jekyll_provider.rb:28:in `block in install'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/hooks.rb:103:in `block in trigger'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/hooks.rb:102:in `each'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/hooks.rb:102:in `trigger'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/site.rb:213:in `render'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/site.rb:80:in `process'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/command.rb:28:in `process_site'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/commands/build.rb:65:in `build'
	from /usr/gem/ruby/2.7.0/gems/jekyll-4.2.1/lib/jekyll/commands/build.rb:36:in `process'
	from /var/jekyll/entrypoint/lib/commands/jekyll_builder.rb:18:in `execute'
	from /var/jekyll/entrypoint/lib/commander.rb:88:in `build'
	from /var/jekyll/entrypoint/lib/commander.rb:65:in `execute_command'
	from /var/jekyll/entrypoint/lib/commander.rb:55:in `execute_args'
	from /var/jekyll/entrypoint/lib/commander.rb:36:in `execute'
	from /var/jekyll/entrypoint/lib/entrypoint.rb:21:in `execute'
	from /var/jekyll/entrypoint/lib/entrypoint.rb:45:in `<main>'
```