### PR TITLE
DX-914: Switch from `post_render` to `post_write`

### DIFF
--- a/lib/kramdown_html.rb
+++ b/lib/kramdown_html.rb
@@ -43,6 +43,7 @@ module Kramdown
       rescue StandardError => e
         raise e if options.raise_errors?
 
+        logger = ::Kramdown::PlantUml::LogWrapper.init
         logger.error "Error while replacing needle: #{e.inspect}"
       end
     end


### PR DESCRIPTION
Switch from `:site:post_render` to `:site:post_write` so the PlantUML theme can be written to disk by Jekyll before PlantUML starts looking for it. Also fix a few other minor things.