### PR TITLE
DX-914: Don't set `:site_destination_dir`

### DIFF
--- a/lib/kramdown-plantuml/jekyll_provider.rb
+++ b/lib/kramdown-plantuml/jekyll_provider.rb
@@ -91,7 +91,6 @@ module Kramdown
 
           needle_hash = JSON.parse(json)
           options_hash = needle_hash['options']
-          options_hash[:site_destination_dir] = @site_destination_dir
           options = ::Kramdown::PlantUml::Options.new({ plantuml: options_hash })
 
           begin


### PR DESCRIPTION
Setting `:site_destination_dir` here may cause the following error if the `options_hash` is `nil`:

```ruby
undefined method `[]=' for nil:NilClass (NoMethodError)
```