### PR TITLE
DX-914: Fix nil key

### DIFF
--- a/lib/kramdown-plantuml/options.rb
+++ b/lib/kramdown-plantuml/options.rb
@@ -10,7 +10,7 @@ module Kramdown
 
       def initialize(options_hash = {})
         @logger = LogWrapper.init
-        @options = massage(options_hash)
+        @options = massage(options_hash) || {}
         @raise_errors = extract_raise_errors(@options)
         extract_theme_options(@options)
       end
@@ -44,9 +44,9 @@ module Kramdown
       end
 
       def extract_theme_options(options)
-        return if options.empty? || !options.key?(:theme)
+        return if options.nil? || options.empty? || !options.key?(:theme)
 
-        theme = options[:theme] || {}
+        theme = options[:theme]
 
         unless theme.is_a?(Hash)
           @logger.warn ":theme is not a Hash: #{theme}"
@@ -58,12 +58,10 @@ module Kramdown
       end
 
       def extract_raise_errors(options)
-        if options.key?(:raise_errors)
-          raise_errors = options[:raise_errors]
-          return boolean(raise_errors, true)
-        end
+        return true if options.nil? || options.empty? || !options.key?(:raise_errors)
 
-        true
+        raise_errors = options[:raise_errors]
+        boolean(raise_errors, true)
       end
 
       def massage(options_hash)

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -37,6 +37,11 @@ describe Options do
     its(:to_h) { is_expected.to eq({ }) }
   end
 
+  context 'nil :theme' do
+    let(:hash) { { plantuml: { theme: nil } } }
+    its(:to_h) { is_expected.to eq({ theme: nil }) }
+  end
+
   context 'empty :theme' do
     let(:hash) { { plantuml: { theme: {  } } } }
     its(:to_h) { is_expected.to eq({ theme: { } }) }

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -24,6 +24,14 @@ describe Options do
     its(:to_h) { is_expected.to eq({ }) }
   end
 
+  context 'nil :plantuml' do
+    let(:hash) { { plantuml: nil } }
+    its(:theme_name) { is_expected.to be_nil }
+    its(:theme_directory) { is_expected.to be_nil }
+    its(:raise_errors?) { is_expected.to be true }
+    its(:to_h) { is_expected.to eq({ }) }
+  end
+
   context 'empty :plantuml' do
     let(:hash) { { plantuml: { } } }
     its(:to_h) { is_expected.to eq({ }) }

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -47,12 +47,27 @@ describe Options do
     its(:to_h) { is_expected.to eq({ theme: { } }) }
   end
 
+  context 'with nil :name' do
+    let(:hash) { { plantuml: { theme: { name: nil } } } }
+    its(:to_h) { is_expected.to eq({ theme: { name: nil } }) }
+  end
+
   context 'with :theme :name' do
     let(:hash) { { plantuml: { theme: { name: 'custom' } } } }
     its(:to_h) { is_expected.to eq({ theme: { name: 'custom' } }) }
   end
 
-  context 'invalid :raise_errors' do
+  context 'with nil :directory' do
+    let(:hash) { { plantuml: { theme: { name: 'custom', directory: nil } } } }
+    its(:to_h) { is_expected.to eq({ theme: { name: 'custom', directory: nil } }) }
+  end
+
+  context 'with nil :raise_errors' do
+    let(:hash) { { plantuml: { theme: { }, raise_errors: nil } } }
+    its(:raise_errors?) { is_expected.to be true }
+  end
+
+  context 'with invalid :raise_errors' do
     let(:hash) { { plantuml: { theme: { }, raise_errors: 'xyz' } } }
     its(:raise_errors?) { is_expected.to be true }
   end


### PR DESCRIPTION
Fix for when the `:plantuml` key is `nil` to avoid the following error:

```ruby
/usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/options.rb:61:in `extract_raise_errors': undefined method `key?' for nil:NilClass (NoMethodError)
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/options.rb:14:in `initialize'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:94:in `new'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:94:in `replace_needle'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:85:in `block in replace_needles'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:83:in `gsub'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:83:in `replace_needles'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:71:in `block (2 levels) in register_hook'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:70:in `each'
	from /usr/gem/ruby/2.7.0/gems/kramdown-plantuml-1.1.10/lib/kramdown-plantuml/jekyll_provider.rb:70:in `block in register_hook'
```