### PR TITLE
Remove deprecated `merge: strict` from Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,10 +9,14 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
+      - '#commits-behind=0' # Only merge up to date pull requests
+      - check-success=Ruby Gem
+      - check-success=No Java
+      - check-success=No PlantUML
+      - check-success=Shell
+      - check-success=license/cla
     actions:
       merge:
-        method: merge
-        strict: smart
 
   - name: Thank contributor
     conditions:


### PR DESCRIPTION
Remove `merge: strict` from the Mergify configuration because it is deprecated:

> The configuration uses the deprecated strict mode of the merge action.
> A brownout is planned for the whole December 6th, 2021 day.
> This option will be removed on January 10th, 2022.
> For more information: https://blog.mergify.com/strict-mode-deprecation/