### PR TITLE
modify how plantuml injects itself in the kramdown process

### DIFF
--- a/lib/kramdown-plantuml/converter_extension.rb
+++ b/lib/kramdown-plantuml/converter_extension.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Kramdown
+  module PlantUml
+    # Plugs into Kramdown::Converter::Html to provide conversion of PlantUML markup
+    # into beautiful SVG.
+    module ConverterExtension
+      def convert_codeblock(element, indent)
+        return super(element, indent) unless plantuml? element
+
+        convert_plantuml(element.value)
+      end
+
+      private
+
+      def plantuml?(element)
+        element.attr['class'] == 'language-plantuml'
+      end
+
+      def convert_plantuml(plantuml)
+        puml_opts = PlantUml::Options.new(@options)
+        diagram = PlantUml::PlantUmlDiagram.new(plantuml, puml_opts)
+        diagram.svg.to_s
+      rescue StandardError => e
+        raise e if puml_opts.nil? || puml_opts.raise_errors?
+
+        logger = PlantUml::LogWrapper.init
+        logger.error "Error while converting diagram: #{e.inspect}"
+      end
+    end
+  end
+end

--- a/lib/kramdown_html.rb
+++ b/lib/kramdown_html.rb
@@ -6,36 +6,6 @@ require_relative 'kramdown-plantuml/log_wrapper'
 require_relative 'kramdown-plantuml/plantuml_error'
 require_relative 'kramdown-plantuml/options'
 require_relative 'kramdown-plantuml/plantuml_diagram'
+require_relative 'kramdown-plantuml/converter_extension'
 
-module Kramdown
-  module Converter
-    # Plugs into Kramdown::Converter::Html to provide conversion of PlantUML markup
-    # into beautiful SVG.
-    class Html
-      alias super_convert_codeblock convert_codeblock
-
-      def convert_codeblock(element, indent)
-        return super_convert_codeblock(element, indent) unless plantuml? element
-
-        convert_plantuml(element.value)
-      end
-
-      private
-
-      def plantuml?(element)
-        element.attr['class'] == 'language-plantuml'
-      end
-
-      def convert_plantuml(plantuml)
-        puml_opts = ::Kramdown::PlantUml::Options.new(@options)
-        diagram = ::Kramdown::PlantUml::PlantUmlDiagram.new(plantuml, puml_opts)
-        diagram.svg.to_s
-      rescue StandardError => e
-        raise e if puml_opts.nil? || puml_opts.raise_errors?
-
-        logger = ::Kramdown::PlantUml::LogWrapper.init
-        logger.error "Error while converting diagram: #{e.inspect}"
-      end
-    end
-  end
-end
+Kramdown::Converter::Html.prepend Kramdown::PlantUml::ConverterExtension


### PR DESCRIPTION
This commit changes how the injection happens from plain monkey
patching to using a module and prepending it into the class hierarchy.

This technique fixes compatibility with middleman. Middleman creates
a subclass of Kramdown::Converter::Html, and this was making the
method-overriding technique fail, while this one works.

To use in middleman, just require "kramdown-plantuml" in config.rb